### PR TITLE
Use `/usr/bin/env` instead of `/bin/env` in hashbang

### DIFF
--- a/keepassxc-proxy-cli.py
+++ b/keepassxc-proxy-cli.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 import sys
 import os
 import json


### PR DESCRIPTION
While `/bin/env` works on Linux, there's no such file on MacOS. Also, quick googling [suggests][1] that `/usr/bin/env` is more universal.

[1]: https://stackoverflow.com/questions/5549044/whats-the-difference-of-using-usr-bin-env-or-bin-env-in-shebang